### PR TITLE
feat: update color scheme to shenzhen-nights

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -30,44 +30,44 @@ const config: QuartzConfig = {
       },
       colors: {
         lightMode: {
-          // Catppuccin Latte
-          light: "#eff1f5", // Base background (Base)
-          lightgray: "#e6e9ef", // Surface (Surface0)
-          gray: "#ccd0da", // Subtle foreground (Surface2)
-          darkgray: "#6c6f85", // Lavender for darker text
-          dark: "#4c4f69", // Dark foreground (Text)
-          secondary: "#1e66f5", // Blue for main links
-          tertiary: "#179299", // Teal for secondary links
-          highlight: "rgba(148, 192, 248, 0.3)", // Subtle highlight (Blue)
-          orgh2: "#1e66f5", // Blue for main headers
-          orgh3: "#179299", // Teal for subheaders
-          orgh4: "#d20f39", // Red for h4
-          orgh5: "#e9b143", // Yellow for h5
-          orgh6: "#40a02b", // Green for h6
-          textHighlight: "#e9b14388", // Yellow text highlight
-          todo1: "#e9b143", // Yellow for todo, idea
-          todo2: "#40a02b", // Green for hold, wait
-          todo3: "#d20f39", // Red for kill, cancel
+          // Shenzhen Nights Light Variant
+          light: "#f8f9fa", // Very light background
+          lightgray: "#e5e9f0", // Light surface (color15)
+          gray: "#b8c2cc", // Subtle foreground (color7)
+          darkgray: "#6B7D8C", // Medium gray text (color8)
+          dark: "#101820", // Dark text (color0)
+          secondary: "#1A8CFF", // Dodger Blue for main links
+          tertiary: "#00CC99", // Mint Green for secondary links
+          highlight: "rgba(26, 140, 255, 0.2)", // Blue highlight
+          orgh2: "#1A8CFF", // Dodger Blue for main headers
+          orgh3: "#00CC99", // Mint Green for subheaders
+          orgh4: "#FF3366", // Folly Red for h4
+          orgh5: "#FFCC00", // Jonquil Yellow for h5
+          orgh6: "#CC33FF", // Phlox Magenta for h6
+          textHighlight: "rgba(255, 204, 0, 0.4)", // Yellow text highlight
+          todo1: "#FFCC00", // Jonquil Yellow for todo, idea
+          todo2: "#00CC99", // Mint Green for hold, wait
+          todo3: "#FF3366", // Folly Red for kill, cancel
         },
         darkMode: {
-          // Catppuccin Mocha
-          light: "#1e1e2e", // Base background (Base)
-          lightgray: "#313244", // Surface (Surface0)
-          gray: "#45475a", // Subtle foreground (Surface2)
-          darkgray: "#b4befe", // Lavender foreground (Text)
-          dark: "#cdd6f4", // Slightly brighter text
-          secondary: "#89b4fa", // Blue for main links
-          tertiary: "#b4befe", // Lavender for secondary links
-          highlight: "rgba(49, 52, 68, 0.5)", // Overlay0
-          orgh2: "#89b4fa", // Blue for main headers
-          orgh3: "#a6e3a1", // Green for subheaders
-          orgh4: "#f38ba8", // Red for h4
-          orgh5: "#f9e2af", // Yellow for h5
-          orgh6: "#b4befe", // Lavender for h6
-          textHighlight: "#94e2d525", // Subtle text highlight (Teal)
-          todo1: "#f9e2af", // Yellow for todo, idea
-          todo2: "#a6e3a1", // Green for hold, wait
-          todo3: "#f38ba8", // Red for kill, cancel
+          // Shenzhen Nights
+          light: "#0a0f14", // Base background
+          lightgray: "#101820", // Darker surface (color0)
+          gray: "#6B7D8C", // Subtle foreground (color8)
+          darkgray: "#d8dce0", // Main foreground text
+          dark: "#e5e9f0", // Bright text (color15)
+          secondary: "#1A8CFF", // Dodger Blue for main links (color4)
+          tertiary: "#00CC99", // Mint Green for secondary links (color2)
+          highlight: "rgba(42, 56, 76, 0.6)", // Selection background with transparency
+          orgh2: "#1A8CFF", // Dodger Blue for main headers
+          orgh3: "#00CC99", // Mint Green for subheaders
+          orgh4: "#FF3366", // Folly Red for h4
+          orgh5: "#FFCC00", // Jonquil Yellow for h5
+          orgh6: "#CC33FF", // Phlox Magenta for h6
+          textHighlight: "rgba(255, 204, 0, 0.3)", // Yellow text highlight
+          todo1: "#FFCC00", // Jonquil Yellow for todo, idea
+          todo2: "#00CC99", // Mint Green for hold, wait
+          todo3: "#FF3366", // Folly Red for kill, cancel
         },
       },
     },
@@ -81,8 +81,8 @@ const config: QuartzConfig = {
       }),
       Plugin.SyntaxHighlighting({
         theme: {
-          light: "catppuccin-latte",
-          dark: "tokyo-night",
+          light: "github-light",
+          dark: "github-dark",
         },
         keepBackground: true,
       }),

--- a/quartz/styles/callouts.scss
+++ b/quartz/styles/callouts.scss
@@ -30,24 +30,24 @@
   --callout-icon-fold: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Cpolyline points="6 9 12 15 18 9"%3E%3C/polyline%3E%3C/svg%3E');
 
   &[data-callout] {
-    --color: #448aff;
-    --border: #448aff44;
-    --bg: #448aff10;
+    --color: #1A8CFF;
+    --border: #1A8CFF44;
+    --bg: #1A8CFF10;
     --callout-icon: var(--callout-icon-note);
   }
 
   &[data-callout="abstract"] {
-    --color: #00b0ff;
-    --border: #00b0ff44;
-    --bg: #00b0ff10;
+    --color: #00CCFF;
+    --border: #00CCFF44;
+    --bg: #00CCFF10;
     --callout-icon: var(--callout-icon-abstract);
   }
 
   &[data-callout="info"],
   &[data-callout="todo"] {
-    --color: #00b8d4;
-    --border: #00b8d444;
-    --bg: #00b8d410;
+    --color: #1A8CFF;
+    --border: #1A8CFF44;
+    --bg: #1A8CFF10;
     --callout-icon: var(--callout-icon-info);
   }
 
@@ -56,39 +56,39 @@
   }
 
   &[data-callout="tip"] {
-    --color: #00bfa5;
-    --border: #00bfa544;
-    --bg: #00bfa510;
+    --color: #00CC99;
+    --border: #00CC9944;
+    --bg: #00CC9910;
     --callout-icon: var(--callout-icon-tip);
   }
 
   &[data-callout="success"] {
-    --color: #09ad7a;
-    --border: #09ad7144;
-    --bg: #09ad7110;
+    --color: #00CC99;
+    --border: #00CC9944;
+    --bg: #00CC9910;
     --callout-icon: var(--callout-icon-success);
   }
 
   &[data-callout="question"] {
-    --color: #dba642;
-    --border: #dba64244;
-    --bg: #dba64210;
+    --color: #FFCC00;
+    --border: #FFCC0044;
+    --bg: #FFCC0010;
     --callout-icon: var(--callout-icon-question);
   }
 
   &[data-callout="warning"] {
-    --color: #db8942;
-    --border: #db894244;
-    --bg: #db894210;
+    --color: #FFCC00;
+    --border: #FFCC0044;
+    --bg: #FFCC0010;
     --callout-icon: var(--callout-icon-warning);
   }
 
   &[data-callout="failure"],
   &[data-callout="danger"],
   &[data-callout="bug"] {
-    --color: #db4242;
-    --border: #db424244;
-    --bg: #db424210;
+    --color: #FF3366;
+    --border: #FF336644;
+    --bg: #FF336610;
     --callout-icon: var(--callout-icon-failure);
   }
 
@@ -101,9 +101,9 @@
   }
 
   &[data-callout="example"] {
-    --color: #7a43b5;
-    --border: #7a43b544;
-    --bg: #7a43b510;
+    --color: #CC33FF;
+    --border: #CC33FF44;
+    --bg: #CC33FF10;
     --callout-icon: var(--callout-icon-example);
   }
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -355,20 +355,20 @@
       @include todo-style(var(--todo1));
     }
     &.PROJ {
-      @include todo-style(#939ed2);
+      @include todo-style(#CC33FF);
     }
     &.WAIT,
     &.HOLD {
       @include todo-style(var(--todo2));
     }
     &.STRT {
-      @include todo-style(#f3935c, #000000, 1000);
+      @include todo-style(#FFCC00, var(--light), 1000);
     }
   }
 
   &.done {
     &.DONE {
-      @include todo-style(#303132, #ffffff);
+      @include todo-style(var(--gray), var(--dark));
     }
     &.KILL,
     &.NO {
@@ -377,7 +377,7 @@
   }
 }
 
-@mixin todo-style($bg-color, $text-color: #ffffff, $font-weight: 600) {
+@mixin todo-style($bg-color, $text-color: var(--light), $font-weight: 600) {
   background-color: $bg-color;
   color: $text-color;
   font-weight: $font-weight;
@@ -690,14 +690,14 @@ aside {
   margin: 25px;
   font-family: var(--codeFont);
   font-size: 0.75em;
-  color: #333;
+  color: var(--darkgray);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   border-radius: 5px;
 
   h2 {
     font-size: 1.2em;
     margin-top: 0;
-    color: #007acc;
+    color: var(--secondary);
   }
 
   p {
@@ -706,9 +706,9 @@ aside {
   }
 
   a {
-    color: #007acc;
+    color: var(--secondary);
     text-decoration: none;
-    border-bottom: 1px dotted #007acc;
+    border-bottom: 1px dotted var(--secondary);
     &:hover {
       text-decoration: underline;
     }
@@ -724,8 +724,8 @@ aside {
   blockquote {
     margin: 1em 0; // Space around the blockquote
     padding-left: 1em; // Indentation for the blockquote
-    border-left: 4px solid #ccc; // Grey left border
-    color: #666; // Slightly lighter text color
+    border-left: 4px solid var(--gray); // Grey left border
+    color: var(--gray); // Slightly lighter text color
   }
 }
 
@@ -1000,35 +1000,35 @@ figure[data-rehype-pretty-code-figure] {
     }
 
     &[data-language="python"]::after {
-      background-color: #3572a5 !important;
+      background-color: #1A8CFF !important;
     }
 
     &[data-language="text"]::after {
-      background-color: #ccc !important;
+      background-color: #6B7D8C !important;
     }
 
     &[data-language="shell"]::after {
-      background-color: #89e051 !important;
+      background-color: #00CC99 !important;
     }
 
     &[data-language="elisp"]::after {
-      background-color: #c065db !important;
+      background-color: #CC33FF !important;
     }
 
     &[data-language="emacs-lisp"]::after {
-      background-color: #c065db !important;
+      background-color: #CC33FF !important;
     }
 
     &[data-language="r"]::after {
-      background-color: #198ce7 !important;
+      background-color: #1A8CFF !important;
     }
 
     &[data-language="markdown"]::after {
-      background-color: #083fa1 !important;
+      background-color: #1A8CFF !important;
     }
 
     &[data-language="org"]::after {
-      background-color: #77aa99 !important;
+      background-color: #00CC99 !important;
     }
   }
 }
@@ -1174,7 +1174,7 @@ ol.overflow {
 /* Spoiler */
 
 .spoiler {
-  background-color: #2c3e50;
+  background-color: var(--lightgray);
   color: transparent;
   border-radius: 5px;
   padding: 0 5px 0 5px;
@@ -1190,7 +1190,7 @@ ol.overflow {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: #ecf0f1;
+  color: var(--darkgray);
   font-size: 0.8em;
   font-weight: bold;
   opacity: 0.7;
@@ -1198,7 +1198,7 @@ ol.overflow {
 }
 
 .spoiler:hover {
-  background-color: #34495e;
+  background-color: var(--gray);
 }
 
 .spoiler:hover::before {
@@ -1207,7 +1207,7 @@ ol.overflow {
 
 .spoiler:active,
 .spoiler:focus {
-  color: #fff;
+  color: var(--dark);
   text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 }
 


### PR DESCRIPTION
updates the site color scheme from tokyo-nights to shenzhen-nights palette.

**changes:**
- updated quartz.config.ts with shenzhen nights colors for both light and dark modes
- fixed callouts and custom styles to match new palette
- switched syntax highlighting to github-dark for better compatibility

fixes #2

generated with [claude code](https://claude.ai/code)