### PR TITLE
fix: ensure explorer event listeners are attached on page load

### DIFF
--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -133,3 +133,6 @@ function toggleCollapsedByPath(array: FolderState[], path: string) {
     entry.collapsed = !entry.collapsed
   }
 }
+
+// Initialize on page load
+setupExplorer()


### PR DESCRIPTION
Fixes issue where explorer button would randomly not respond to clicks.

The setupExplorer() function was only called on resize/nav events, leaving the explorer button without click handlers on initial page load.

Now calls setupExplorer() immediately when script loads to ensure event listeners are always attached.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)