### PR TITLE
fix: prevent white flash during navigation in dark mode

### DIFF
--- a/quartz/components/scripts/spa.inline.ts
+++ b/quartz/components/scripts/spa.inline.ts
@@ -67,6 +67,12 @@ async function navigate(url: URL, isBack: boolean = false) {
   const html = p.parseFromString(contents, "text/html")
   normalizeRelativeURLs(html, url)
 
+  // preserve theme during navigation to prevent white flash
+  const currentTheme = document.documentElement.getAttribute("saved-theme")
+  if (currentTheme) {
+    html.documentElement.setAttribute("saved-theme", currentTheme)
+  }
+
   let title = html.querySelector("title")?.textContent
   if (title) {
     document.title = title


### PR DESCRIPTION
Preserve the current theme attribute on the new HTML document before micromorph processes it during SPA navigation. This ensures dark mode styling is applied immediately without any jarring white flash.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)